### PR TITLE
update test dataset seeders

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -25,6 +25,8 @@ class DatabaseSeeder extends Seeder
             $this->call("Database\Seeders\DatasetSeeders\\$class");
         }
 
+        $this->call(TapeDatasetSeeders::class);
+
 
 
         $this->call(AeZoneSeeder::class);

--- a/database/seeders/TapeDatasetSeeders.php
+++ b/database/seeders/TapeDatasetSeeders.php
@@ -9,40 +9,127 @@ use Illuminate\Database\Seeder;
 class TapeDatasetSeeders extends Seeder
 {
     /**
-     * Run the database seeds.
+     * Add datasets for the sample frame and TAPE survey data outputs
      */
     public function run(): void
     {
+        // SAMPLE FRAME
         $farmDataset = Dataset::create([
             'name' => 'Farms',
             'primary_key' => 'id',
             'entity_model' => Farm::class,
-        ]);
-
-        $caetScaleDataset = Dataset::create([
-            'name' => 'Caet Scales',
-            'primary_key' => 'id',
-            'entity_model' => \App\Models\CaetScale::class,
-        ]);
-
-        $caetInterpretationsDataset = Dataset::create([
-            'name' => 'Caet Interpretations',
-            'primary_key' => 'id',
-            'entity_model' => \App\Models\CaetInterpretation::class,
+            'lookup_table' => 1,
         ]);
 
         $locationLevelDataset = Dataset::create([
             'name' => 'Location Levels',
             'primary_key' => 'id',
             'entity_model' => \App\Models\SampleFrame\LocationLevel::class,
+            'lookup_table' => 1,
         ]);
 
         $locationDataset = Dataset::create([
             'name' => 'Locations',
             'primary_key' => 'id',
             'entity_model' => \App\Models\SampleFrame\Location::class,
+            'lookup_table' => 1,
         ]);
 
+
+        // EXTRA TAPE LOOKUPS
+        $caetScaleDataset = Dataset::create([
+            'name' => 'Caet Scales',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\CaetScale::class,
+            'lookup_table' => 1,
+            'is_universal' => 1,
+        ]);
+
+        $caetInterpretationsDataset = Dataset::create([
+            'name' => 'Caet Interpretations',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\CaetInterpretation::class,
+            'lookup_table' => 1,
+        ]);
+
+        // TAPE SURVEY DATA
+        $caetAssessmentDataset = Dataset::create([
+            'name' => 'CAET Assessments',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\SurveyData\CaetAssessment::class,
+        ]);
+
+        $performanceAssessmentDataset = Dataset::create([
+            'name' => 'Performance Assessments',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\SurveyData\PerformanceAssessment::class,
+        ]);
+
+        $performanceActivitiesDataset = Dataset::create([
+            'name' => 'Performance Assessments - Activities',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\SurveyData\Performance\PerformanceActivity::class,
+        ]);
+
+        $performanceAnimalDataset = Dataset::create([
+            'name' => 'Performance Assessments - Animals',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\SurveyData\Performance\PerformanceAnimal::class,
+        ]);
+
+        $performanceAnimalProductDataset = Dataset::create([
+            'name' => 'Performance Assessments - Animal Products',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\SurveyData\Performance\PerformanceAnimalProduct::class,
+        ]);
+
+        $performanceChemicalPesticideDataset = Dataset::create([
+            'name' => 'Performance Assessments - Chemical Pesticides',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\SurveyData\Performance\PerformanceChemicalPesticide::class,
+        ]);
+
+        $performanceCropDataset = Dataset::create([
+            'name' => 'Performance Assessments - Crops',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\SurveyData\Performance\PerformanceCrop::class,
+        ]);
+
+        $performanceCropProductDataset = Dataset::create([
+            'name' => 'Performance Assessments - Crop Products',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\SurveyData\Performance\PerformanceCropProduct::class,
+        ]);
+
+        $performanceMachineDataset = Dataset::create([
+            'name' => 'Performance Assessments - Machines',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\SurveyData\Performance\PerformanceMachine::class,
+        ]);
+
+        $performanceOrganicPesticideDataset = Dataset::create([
+            'name' => 'Performance Assessments - Organic Pesticides',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\SurveyData\Performance\PerformanceOrganicPesticide::class,
+        ]);
+
+        $performanceYouthEmigrantDataset = Dataset::create([
+            'name' => 'Performance Assessments - Youth Emigrants',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\SurveyData\Performance\PerformanceYouthEmigrant::class,
+        ]);
+
+        $performanceYouthFemaleDataset = Dataset::create([
+            'name' => 'Performance Assessments - Youth Female',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\SurveyData\Performance\PerformanceYouthFemale::class,
+        ]);
+
+        $performanceYouthMaleDataset = Dataset::create([
+            'name' => 'Performance Assessments - Youth Male',
+            'primary_key' => 'id',
+            'entity_model' => \App\Models\SurveyData\Performance\PerformanceYouthMale::class,
+        ]);
 
 
     }

--- a/database/seeders/TestDatasetSeeder.php
+++ b/database/seeders/TestDatasetSeeder.php
@@ -12,7 +12,7 @@ class TestDatasetSeeder extends Seeder
 {
     public function run(): void
     {
-        // T EMP
+        // TEMP
         CaetAssessment::destroy(CaetAssessment::all()->pluck('id'));
         PerformanceAssessment::destroy(PerformanceAssessment::all()->pluck('id'));
 


### PR DESCRIPTION
Adds datasets to enable the sample frame entries to be used as lookup tables in the main survey.

Also adds datasets to hold the survey data (caet and performance). 

NOTE - right now, the main survey can only be linked to a single dataset. When handling the odk data (#6) We will need to either:

- have a single dataset that includes *all* the non-repeatgroup data from the submissions;
- update the xlsform handling to let us link different parts of the survey to different datasets (#7)

