### PR TITLE
Register team as app/models/team instead of package team

### DIFF
--- a/app/Filament/App/Pages/RegisterTeam.php
+++ b/app/Filament/App/Pages/RegisterTeam.php
@@ -5,7 +5,7 @@ namespace App\Filament\App\Pages;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Pages\Tenancy\RegisterTenant;
-use Stats4sd\FilamentOdkLink\Models\TeamManagement\Team;
+use App\Models\Team;
 
 class RegisterTeam extends RegisterTenant
 {


### PR DESCRIPTION
A simple fix to the main TAPE app, so it uses the app team model when creating a new Team via the RegisterTeam front-end. 

Before this fix, creating a new team via the front end resulted in the OdkProject being linked to the book-link package Team model instead of the app team model, causing the ODK Form Management page to fail. 

Now, the system works. 

NOTE: I would like to do a better refactor at some point, and entirely remove the "package" version of the Team Model. See [here](https://github.com/stats4sd/filament-odk-link/issues/19)