### PR TITLE
Remove default list options

### DIFF
--- a/app/Http/Middleware/SetLatestTeamMiddleware.php
+++ b/app/Http/Middleware/SetLatestTeamMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Filament\Facades\Filament;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SetLatestTeamMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+
+        auth()->user()->latestTeam()->associate(Filament::getTenant())->save();
+
+        return $next($request);
+    }
+}

--- a/app/Models/CaetInterpretation.php
+++ b/app/Models/CaetInterpretation.php
@@ -2,18 +2,12 @@
 
 namespace App\Models;
 
-use App\Models\Interfaces\LookupListEntry;
-use App\Models\Traits\HasLinkedDataset;
-use App\Models\Traits\IsLookupList;
+use App\Models\LookupTables\LookupEntry;
 use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class CaetInterpretation extends Model implements LookupListEntry
+class CaetInterpretation extends LookupEntry
 {
-    use HasLinkedDataset;
-    use IsLookupList;
-
     public function hasContextualisedInterpretation(): Attribute
     {
         return new Attribute(

--- a/app/Models/CaetInterpretation.php
+++ b/app/Models/CaetInterpretation.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Models\LookupTables\LookupEntry;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 class CaetInterpretation extends LookupEntry
 {
@@ -34,7 +35,7 @@ class CaetInterpretation extends LookupEntry
         return true;
     }
 
-    public function getCsvContentsForOdk(): array
+    public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
 
         return [

--- a/app/Models/CaetScale.php
+++ b/app/Models/CaetScale.php
@@ -2,17 +2,11 @@
 
 namespace App\Models;
 
-use App\Models\Interfaces\LookupListEntry;
-use App\Models\Traits\HasLinkedDataset;
-use App\Models\Traits\IsLookupList;
-use Illuminate\Database\Eloquent\Model;
+use App\Models\LookupTables\LookupEntry;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class CaetScale extends Model implements LookupListEntry
+class CaetScale extends LookupEntry
 {
-    use HasLinkedDataset;
-    use IsLookupList;
-
     public function caetIndex(): BelongsTo
     {
         return $this->belongsTo(CaetIndex::class);

--- a/app/Models/CaetScale.php
+++ b/app/Models/CaetScale.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Models\LookupTables\LookupEntry;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 class CaetScale extends LookupEntry
 {
@@ -12,7 +13,7 @@ class CaetScale extends LookupEntry
         return $this->belongsTo(CaetIndex::class);
     }
 
-    public function getCsvContentsForOdk(): array
+    public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         return [
             'id' => $this->id,

--- a/app/Models/Interfaces/LookupListEntry.php
+++ b/app/Models/Interfaces/LookupListEntry.php
@@ -3,6 +3,8 @@
 namespace App\Models\Interfaces;
 
 // The required methods for a model to be used as a source for a csv file that will be published to ODK as a media attachment.
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
+
 interface LookupListEntry
 {
     public static function getLinkedDataset(): ?\App\Models\Dataset;
@@ -18,6 +20,6 @@ interface LookupListEntry
     public function owner(): \Illuminate\Database\Eloquent\Relations\MorphTo;
 
     // Defines what goes into the csv file that will be published to ODK
-    public function getCsvContentsForOdk(): array;
+    public function getCsvContentsForOdk(?WithXlsforms $team = null): array;
 
 }

--- a/app/Models/LookupTables/Animal.php
+++ b/app/Models/LookupTables/Animal.php
@@ -2,12 +2,11 @@
 
 namespace App\Models\LookupTables;
 
+use App\Models\Traits\CanBeHiddenFromContext;
+
 class Animal extends LookupEntry
 {
-//    protected static function booted(): void
-//    {
-//        parent::booted();
-//    }
+    use CanBeHiddenFromContext;
 
     public function getCsvContentsForOdk(): array
     {

--- a/app/Models/LookupTables/Animal.php
+++ b/app/Models/LookupTables/Animal.php
@@ -3,17 +3,26 @@
 namespace App\Models\LookupTables;
 
 use App\Models\Traits\CanBeHiddenFromContext;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 class Animal extends LookupEntry
 {
     use CanBeHiddenFromContext;
 
-    public function getCsvContentsForOdk(): array
+    public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
+        if ($team) {
+            ray('team', $team->id);
+            $isRelevant = $this->isRemoved($team) ? 0 : 1;
+        } else {
+            $isRelevant = null;
+        }
+
         return [
             'id'  => $this->id,
             'name' => $this->name,
             'label' => $this->label,
+            'relevant_to_context' => $isRelevant,
         ];
     }
 }

--- a/app/Models/LookupTables/AnimalProduct.php
+++ b/app/Models/LookupTables/AnimalProduct.php
@@ -2,8 +2,12 @@
 
 namespace App\Models\LookupTables;
 
+use App\Models\Traits\CanBeHiddenFromContext;
+
 class AnimalProduct extends LookupEntry
 {
+    use CanBeHiddenFromContext;
+
     public function getCsvContentsForOdk(): array
     {
         return [

--- a/app/Models/LookupTables/AnimalProduct.php
+++ b/app/Models/LookupTables/AnimalProduct.php
@@ -3,17 +3,20 @@
 namespace App\Models\LookupTables;
 
 use App\Models\Traits\CanBeHiddenFromContext;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 class AnimalProduct extends LookupEntry
 {
     use CanBeHiddenFromContext;
 
-    public function getCsvContentsForOdk(): array
+    public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         return [
             'id'  => $this->id,
             'name' => $this->name,
             'label' => $this->label,
+            'is_in_context' => $team ? $this->isRemoved($team) : null,
+
         ];
     }
 }

--- a/app/Models/LookupTables/Crop.php
+++ b/app/Models/LookupTables/Crop.php
@@ -2,15 +2,11 @@
 
 namespace App\Models\LookupTables;
 
-use App\Models\Team;
-use App\Models\Traits\HasLinkedDataset;
-use App\Models\Traits\IsLookupList;
-use Filament\Facades\Filament;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\Traits\CanBeHiddenFromContext;
 
 class Crop extends LookupEntry
 {
-
+    use CanBeHiddenFromContext;
 
     public function getCsvContentsForOdk(): array
     {

--- a/app/Models/LookupTables/Crop.php
+++ b/app/Models/LookupTables/Crop.php
@@ -3,17 +3,20 @@
 namespace App\Models\LookupTables;
 
 use App\Models\Traits\CanBeHiddenFromContext;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 class Crop extends LookupEntry
 {
     use CanBeHiddenFromContext;
 
-    public function getCsvContentsForOdk(): array
+    public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         return [
             'id'  => $this->id,
             'name' => $this->name,
             'label' => $this->label,
+            'is_in_context' => $team ? $this->isRemoved($team) : null,
+
         ];
     }
 }

--- a/app/Models/LookupTables/CropProduct.php
+++ b/app/Models/LookupTables/CropProduct.php
@@ -3,17 +3,20 @@
 namespace App\Models\LookupTables;
 
 use App\Models\Traits\CanBeHiddenFromContext;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 class CropProduct extends LookupEntry
 {
     use CanBeHiddenFromContext;
 
-    public function getCsvContentsForOdk(): array
+    public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         return [
             'id' => $this->id,
             'name' => $this->name,
             'label' => $this->label,
+            'is_in_context' => $team ? $this->isRemoved($team) : null,
+
         ];
     }
 }

--- a/app/Models/LookupTables/CropProduct.php
+++ b/app/Models/LookupTables/CropProduct.php
@@ -2,16 +2,11 @@
 
 namespace App\Models\LookupTables;
 
-use App\Models\Interfaces\LookupListEntry;
-use App\Models\Team;
-use App\Models\Traits\HasLinkedDataset;
-use App\Models\Traits\IsLookupList;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\Traits\CanBeHiddenFromContext;
 
 class CropProduct extends LookupEntry
 {
-
+    use CanBeHiddenFromContext;
 
     public function getCsvContentsForOdk(): array
     {

--- a/app/Models/LookupTables/Enumerator.php
+++ b/app/Models/LookupTables/Enumerator.php
@@ -2,14 +2,11 @@
 
 namespace App\Models\LookupTables;
 
-use App\Models\Interfaces\LookupListEntry;
-use App\Models\Traits\HasLinkedDataset;
-use App\Models\Traits\IsLookupList;
-use Illuminate\Database\Eloquent\Model;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 class Enumerator extends LookupEntry
 {
-    public function getCsvContentsForOdk(): array
+    public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         return [
             'id'  => $this->id,

--- a/app/Models/LookupTables/LookupEntry.php
+++ b/app/Models/LookupTables/LookupEntry.php
@@ -6,6 +6,7 @@ use App\Models\Interfaces\LookupListEntry;
 use App\Models\Traits\HasLinkedDataset;
 use App\Models\Traits\IsLookupList;
 use Illuminate\Database\Eloquent\Model;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 // Generic Class for models that are entries in a lookup table (i.e. they are linked to a dataset that will be used to create csv files for ODK media attachments).
 
@@ -33,7 +34,7 @@ class LookupEntry extends Model implements LookupListEntry
     }
 
     // Generic CSV content. Should be overwritten by specific classes when the csv file contents needs to be specific.
-    public function getCsvContentsForOdk(): array
+    public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         return [
             'id' => $this->id,

--- a/app/Models/LookupTables/LookupEntry.php
+++ b/app/Models/LookupTables/LookupEntry.php
@@ -26,6 +26,12 @@ class LookupEntry extends Model implements LookupListEntry
         });
     }
 
+    // Set default. This is overwritten by the CanBeHiddenFromContext trait in some cases.
+    public static function canBeHiddenFromContext(): bool
+    {
+        return false;
+    }
+
     // Generic CSV content. Should be overwritten by specific classes when the csv file contents needs to be specific.
     public function getCsvContentsForOdk(): array
     {

--- a/app/Models/LookupTables/Unit.php
+++ b/app/Models/LookupTables/Unit.php
@@ -2,12 +2,9 @@
 
 namespace App\Models\LookupTables;
 
-use App\Models\Interfaces\LookupListEntry;
-use App\Models\Traits\HasLinkedDataset;
-use App\Models\Traits\IsLookupList;
 use App\Models\UnitType;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 class Unit extends LookupEntry
 {
@@ -16,7 +13,7 @@ class Unit extends LookupEntry
         return $this->belongsTo(UnitType::class);
     }
 
-    public function getCsvContentsForOdk(): array
+    public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         return [
             'id'  => $this->id,

--- a/app/Models/SampleFrame/Farm.php
+++ b/app/Models/SampleFrame/Farm.php
@@ -2,22 +2,16 @@
 
 namespace App\Models\SampleFrame;
 
-use App\Models\Interfaces\LookupListEntry;
+use App\Models\LookupTables\LookupEntry;
 use App\Models\Site;
 use App\Models\SurveyData\CaetAssessment;
 use App\Models\SurveyData\PerformanceAssessment;
-use App\Models\Traits\HasLinkedDataset;
-use App\Models\Traits\IsLookupList;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
-class Farm extends Model implements LookupListEntry
+class Farm extends LookupEntry
 {
-    use HasLinkedDataset;
-    use IsLookupList;
-
     protected $casts = [
         'identifiers' => 'collection',
         'properties' => 'collection',

--- a/app/Models/SampleFrame/Farm.php
+++ b/app/Models/SampleFrame/Farm.php
@@ -9,6 +9,7 @@ use App\Models\SurveyData\PerformanceAssessment;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 class Farm extends LookupEntry
 {
@@ -32,14 +33,16 @@ class Farm extends LookupEntry
         return $this->hasMany(PerformanceAssessment::class);
     }
 
-    public function getCsvContentsForOdk(): array
+    public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         return [
             'id'  => $this->id,
             'location_id' => $this->location_id,
             'location_name' => $this->location?->name,
             'team_code' => $this->team_code,
-            'label' => $this->label,
+            'name' => $this->identifiers ? $this->identifiers['name'] : '',
+            'sex' => $this->properties ? $this->properties['sex'] : '',
+            'year' => $this->properties ? $this->properties['year'] : '',
         ];
     }
 

--- a/app/Models/SampleFrame/Location.php
+++ b/app/Models/SampleFrame/Location.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Facades\Cache;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 class Location extends LookupEntry
 {
@@ -79,7 +80,7 @@ class Location extends LookupEntry
         );
     }
 
-    public function getCsvContentsForOdk(): array
+    public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         return [
             'id' => $this->id,

--- a/app/Models/SampleFrame/Location.php
+++ b/app/Models/SampleFrame/Location.php
@@ -2,20 +2,15 @@
 
 namespace App\Models\SampleFrame;
 
-use App\Models\Interfaces\LookupListEntry;
-use App\Models\Traits\HasLinkedDataset;
-use App\Models\Traits\IsLookupList;
+use App\Models\LookupTables\LookupEntry;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Facades\Cache;
 
-class Location extends Model implements LookupListEntry
+class Location extends LookupEntry
 {
-    use HasLinkedDataset;
-    use IsLookupList;
-
     protected $casts = [
         'properties' => 'collection',
     ];

--- a/app/Models/SampleFrame/LocationLevel.php
+++ b/app/Models/SampleFrame/LocationLevel.php
@@ -2,22 +2,16 @@
 
 namespace App\Models\SampleFrame;
 
-use App\Models\Interfaces\LookupListEntry;
+use App\Models\LookupTables\LookupEntry;
 use App\Models\Team;
-use App\Models\Traits\HasLinkedDataset;
-use App\Models\Traits\IsLookupList;
 use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 
-class LocationLevel extends Model implements LookupListEntry
+class LocationLevel extends LookupEntry
 {
-    use HasLinkedDataset;
-    use IsLookupList;
-
     protected static function booted(): void
     {
         static::saving(function (self $locationLevel) {

--- a/app/Models/SampleFrame/LocationLevel.php
+++ b/app/Models/SampleFrame/LocationLevel.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 class LocationLevel extends LookupEntry
 {
@@ -69,7 +70,7 @@ class LocationLevel extends LookupEntry
         );
     }
 
-    public function getCsvContentsForOdk(): array
+    public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         return [
             'id' => $this->id,

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -93,6 +93,11 @@ class Team extends \Stats4sd\FilamentOdkLink\Models\TeamManagement\Team
         return $this->morphMany(Animal::class, 'owner');
     }
 
+    public function animalsRemoved(): BelongsToMany
+    {
+        return $this->belongsToMany(Animal::class, 'animal_team_removed');
+    }
+
     public function animalProducts(): MorphMany
     {
         return $this->morphMany(AnimalProduct::class, 'owner');

--- a/app/Models/Traits/CanBeHiddenFromContext.php
+++ b/app/Models/Traits/CanBeHiddenFromContext.php
@@ -5,6 +5,7 @@ namespace App\Models\Traits;
 use App\Models\Team;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Str;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 // Trait to use on LookupEntry models when the user can remove 'global' entries from their own context. E.g. For Crops - a user can remove a crop from their own context, and so it will not show in the shortened list of crops in the ODK form. (but will appear in the full list if the enumerator selects "other"...
 trait CanBeHiddenFromContext
@@ -19,12 +20,12 @@ trait CanBeHiddenFromContext
         return $this->BelongsToMany(Team::class, Str::snake(class_basename($this)) . '_team_removed');
     }
 
-    public function isRemoved(Team $team): bool
+    public function isRemoved(WithXlsforms $team): bool
     {
         return $this->teamRemoved->contains($team);
     }
 
-    public function toggleRemoved(Team $team): array
+    public function toggleRemoved(WithXlsforms $team): array
     {
         return $this->teamRemoved()->toggle([$team->id]);
     }

--- a/app/Models/Traits/CanBeHiddenFromContext.php
+++ b/app/Models/Traits/CanBeHiddenFromContext.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models\Traits;
+
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Str;
+
+// Trait to use on LookupEntry models when the user can remove 'global' entries from their own context. E.g. For Crops - a user can remove a crop from their own context, and so it will not show in the shortened list of crops in the ODK form. (but will appear in the full list if the enumerator selects "other"...
+trait CanBeHiddenFromContext
+{
+    public static function canBeHiddenFromContext(): bool
+    {
+        return true;
+    }
+
+    public function teamRemoved(): BelongsToMany
+    {
+        return $this->BelongsToMany(Team::class, Str::snake(class_basename($this)) . '_team_removed');
+    }
+
+    public function isRemoved(Team $team): bool
+    {
+        return $this->teamRemoved->contains($team);
+    }
+
+    public function toggleRemoved(Team $team): array
+    {
+        return $this->teamRemoved()->toggle([$team->id]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,10 +5,12 @@ namespace App\Models;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasAvatar;
+use Filament\Models\Contracts\HasDefaultTenant;
 use Filament\Models\Contracts\HasTenants;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -18,7 +20,7 @@ use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
 use Stats4sd\FilamentOdkLink\Models\TeamManagement\Traits\HasTeamMemberships;
 
-class User extends Authenticatable implements FilamentUser, HasAvatar, HasTenants
+class User extends Authenticatable implements FilamentUser, HasAvatar, HasTenants, HasDefaultTenant
 {
     use HasApiTokens;
     use HasFactory;
@@ -66,10 +68,23 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasTenant
         return $this->can('view all teams') ? Team::all() : $this->teams;
     }
 
+    // The last team the user was on.
+    public function latestTeam(): BelongsTo
+    {
+        return $this->belongsTo(Team::class, 'latest_team_id');
+    }
+
+
+    public function getDefaultTenant(Panel $panel): ?Model
+    {
+        return $this->latestTeam;
+    }
+
     // ******* RELATIONSHIPS
 
     public function imports(): HasMany
     {
         return $this->hasMany(Import::class);
     }
+
 }

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -11,6 +11,7 @@ use App\Filament\App\Resources\FarmResource;
 use App\Filament\App\Resources\ImportResource;
 use App\Filament\App\Resources\LocationLevelResource;
 use App\Filament\App\Resources\SiteResource;
+use App\Http\Middleware\SetLatestTeamMiddleware;
 use App\Models\Team;
 use BetterFuturesStudio\FilamentLocalLogins\LocalLogins;
 use Filament\Http\Middleware\Authenticate;
@@ -44,6 +45,9 @@ class AppPanelProvider extends PanelProvider
             ->viteTheme('resources/css/filament/app/theme.css')
             ->tenant(Team::class)
             ->tenantRegistration(RegisterTeam::class)
+            ->tenantMiddleware([
+                SetLatestTeamMiddleware::class,
+            ])
             ->login()
             ->passwordReset()
             ->profile() // TODO: Implement more full-featured profile page

--- a/database/migrations/2024_05_08_141413_add_latest_team_id_to_users_table.php
+++ b/database/migrations/2024_05_08_141413_add_latest_team_id_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('latest_team_id')->nullable()->constrained('teams')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2024_05_08_143317_create_animal_team_table.php
+++ b/database/migrations/2024_05_08_143317_create_animal_team_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('animal_team_removed', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('team_id');
+            $table->foreignId('animal_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('animal_team_removed');
+    }
+};

--- a/database/migrations/2024_05_08_151247_add_other_team_removed_tables.php
+++ b/database/migrations/2024_05_08_151247_add_other_team_removed_tables.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('animal_product_team_removed', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('team_id');
+            $table->foreignId('animal_product_id');
+            $table->timestamps();
+        });
+
+        Schema::create('crop_team_removed', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('team_id');
+            $table->foreignId('crop_id');
+            $table->timestamps();
+        });
+
+        Schema::create('crop_product_team_removed', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('team_id');
+            $table->foreignId('crop_product_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};


### PR DESCRIPTION
Allows Teams to 'hide' global lookup entries from their context. 

- Adds a 'CanBeRemovedFromContext' trait for LookupEntry models. 
- a new 'is_in_context' column in csv lookup tables allows the ODK form to filter those lists. So e.g. - the first 'crops' question shows the team-specific entries + the global entries that are *not* removed. If the enumerator chooses 'other', there is a second question that has all the global options.