### PR TITLE
Store latest team on user model

### DIFF
--- a/app/Http/Middleware/SetLatestTeamMiddleware.php
+++ b/app/Http/Middleware/SetLatestTeamMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Filament\Facades\Filament;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SetLatestTeamMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+
+        auth()->user()->latestTeam()->associate(Filament::getTenant())->save();
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,10 +5,12 @@ namespace App\Models;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasAvatar;
+use Filament\Models\Contracts\HasDefaultTenant;
 use Filament\Models\Contracts\HasTenants;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -18,7 +20,7 @@ use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
 use Stats4sd\FilamentOdkLink\Models\TeamManagement\Traits\HasTeamMemberships;
 
-class User extends Authenticatable implements FilamentUser, HasAvatar, HasTenants
+class User extends Authenticatable implements FilamentUser, HasAvatar, HasTenants, HasDefaultTenant
 {
     use HasApiTokens;
     use HasFactory;
@@ -66,10 +68,23 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasTenant
         return $this->can('view all teams') ? Team::all() : $this->teams;
     }
 
+    // The last team the user was on.
+    public function latestTeam(): BelongsTo
+    {
+        return $this->belongsTo(Team::class, 'latest_team_id');
+    }
+
+
+    public function getDefaultTenant(Panel $panel): ?Model
+    {
+        return $this->latestTeam;
+    }
+
     // ******* RELATIONSHIPS
 
     public function imports(): HasMany
     {
         return $this->hasMany(Import::class);
     }
+
 }

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -11,6 +11,7 @@ use App\Filament\App\Resources\FarmResource;
 use App\Filament\App\Resources\ImportResource;
 use App\Filament\App\Resources\LocationLevelResource;
 use App\Filament\App\Resources\SiteResource;
+use App\Http\Middleware\SetLatestTeamMiddleware;
 use App\Models\Team;
 use BetterFuturesStudio\FilamentLocalLogins\LocalLogins;
 use Filament\Http\Middleware\Authenticate;
@@ -44,6 +45,9 @@ class AppPanelProvider extends PanelProvider
             ->viteTheme('resources/css/filament/app/theme.css')
             ->tenant(Team::class)
             ->tenantRegistration(RegisterTeam::class)
+            ->tenantMiddleware([
+                SetLatestTeamMiddleware::class,
+            ])
             ->login()
             ->passwordReset()
             ->profile() // TODO: Implement more full-featured profile page

--- a/database/migrations/2024_05_08_141413_add_latest_team_id_to_users_table.php
+++ b/database/migrations/2024_05_08_141413_add_latest_team_id_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('latest_team_id')->nullable()->constrained('teams')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};


### PR DESCRIPTION
Small PR to fix something that was bugging me while testing - I had multiple teams locally, and each time I moved back from the admin panel to the main app panel, I would get put back onto the first team. 

This PR makes it so that the database stores the 'latest team' accessed by a user, so when they return to the app panel they will still be viewing that latest team. 