### PR TITLE
Add main or replacement to farms csv

### DIFF
--- a/app/Models/SampleFrame/Farm.php
+++ b/app/Models/SampleFrame/Farm.php
@@ -50,6 +50,7 @@ class Farm extends LookupEntry
             'name' => $this->identifiers ? $this->identifiers['name'] : '',
             'sex' => $this->properties ? $this->properties['sex'] : '',
             'year' => $this->properties ? $this->properties['year'] : '',
+            'beneficiary' => $this->properties ? $this->properties['beneficiary'] : 0,
             'reserve' => $this->identifiers ? $this->identifiers['reserve'] : '',
         ];
     }

--- a/app/Models/SampleFrame/Farm.php
+++ b/app/Models/SampleFrame/Farm.php
@@ -50,8 +50,7 @@ class Farm extends LookupEntry
             'name' => $this->identifiers ? $this->identifiers['name'] : '',
             'sex' => $this->properties ? $this->properties['sex'] : '',
             'year' => $this->properties ? $this->properties['year'] : '',
-            'beneficiary' => $this->properties ? $this->properties['beneficiary'] : 0,
-            'reserve' => $this->identifiers ? $this->identifiers['reserve'] : '',
+            'reserve' => $this->identifiers ? $this->identifiers['reserve'] : '', // value is 0 = beneficiary farm that is not a reserve; 1 = beneficiary farm that is a reserve; '' = non-beneficiary farm.
         ];
     }
 

--- a/app/Models/SampleFrame/Farm.php
+++ b/app/Models/SampleFrame/Farm.php
@@ -50,6 +50,7 @@ class Farm extends LookupEntry
             'name' => $this->identifiers ? $this->identifiers['name'] : '',
             'sex' => $this->properties ? $this->properties['sex'] : '',
             'year' => $this->properties ? $this->properties['year'] : '',
+            'reserve' => $this->identifiers ? $this->identifiers['reserve'] : '',
         ];
     }
 


### PR DESCRIPTION
For the ODK farm sample list, we are already filtering by location, so we have 1 more available filter in the search() method. So `reserve` now encodes both the main sample or reserve *and* whether the farm is a beneficiary farm or not: 

0 = main sample beneficiary
1 = reserve beneficiary 
empty or null = non-beneficiary. 