### PR TITLE
Add 'others' to csv files

### DIFF
--- a/app/Models/Interfaces/LookupListEntry.php
+++ b/app/Models/Interfaces/LookupListEntry.php
@@ -19,6 +19,12 @@ interface LookupListEntry
 
     public function owner(): \Illuminate\Database\Eloquent\Relations\MorphTo;
 
+    /**
+     * Function to generate any extra rows that are always required for the csv lookup file (e.g. "other", "none", etc)
+     * When using search(), these rows are usually specified in the XLSform itself, but when using select_*_from_file all the entries must be in the file)
+     */
+    public function getExtraCsvRows(): ?array;
+
     // Defines what goes into the csv file that will be published to ODK
     public function getCsvContentsForOdk(?WithXlsforms $team = null): array;
 

--- a/app/Models/Interfaces/LookupListEntry.php
+++ b/app/Models/Interfaces/LookupListEntry.php
@@ -23,7 +23,7 @@ interface LookupListEntry
      * Function to generate any extra rows that are always required for the csv lookup file (e.g. "other", "none", etc)
      * When using search(), these rows are usually specified in the XLSform itself, but when using select_*_from_file all the entries must be in the file)
      */
-    public function getExtraCsvRows(): ?array;
+    public static function getExtraCsvRows(): ?array;
 
     // Defines what goes into the csv file that will be published to ODK
     public function getCsvContentsForOdk(?WithXlsforms $team = null): array;

--- a/app/Models/LookupTables/Animal.php
+++ b/app/Models/LookupTables/Animal.php
@@ -9,6 +9,24 @@ class Animal extends LookupEntry
 {
     use CanBeHiddenFromContext;
 
+    public function getExtraCsvRows(): array
+    {
+        return [
+            [
+                'id' => null,
+                'name' => 77,
+                'label' => 'other',
+                'is_in_context' => 1,
+            ],
+            [
+                'id' => null,
+                'name' => 77,
+                'label' => 'other',
+                'is_in_context' => 0,
+            ],
+        ];
+    }
+
     public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         if ($team) {

--- a/app/Models/LookupTables/Animal.php
+++ b/app/Models/LookupTables/Animal.php
@@ -9,7 +9,7 @@ class Animal extends LookupEntry
 {
     use CanBeHiddenFromContext;
 
-    public function getExtraCsvRows(): array
+    public static function getExtraCsvRows(): array
     {
         return [
             [

--- a/app/Models/LookupTables/AnimalProduct.php
+++ b/app/Models/LookupTables/AnimalProduct.php
@@ -9,6 +9,31 @@ class AnimalProduct extends LookupEntry
 {
     use CanBeHiddenFromContext;
 
+        public function getExtraCsvRows(): array
+    {
+        return [
+            [
+                'id' => null,
+                'name' => 77,
+                'label' => 'Other',
+                'is_in_context' => 1,
+            ],
+            [
+                'id' => null,
+                'name' => -97,
+                'label' => 'None',
+                'is_in_context' => 1,
+            ],
+            [
+                'id' => null,
+                'name' => 77,
+                'label' => 'Other',
+                'is_in_context' => 0,
+            ],
+        ];
+    }
+
+
     public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         if ($team) {

--- a/app/Models/LookupTables/AnimalProduct.php
+++ b/app/Models/LookupTables/AnimalProduct.php
@@ -9,7 +9,7 @@ class AnimalProduct extends LookupEntry
 {
     use CanBeHiddenFromContext;
 
-        public function getExtraCsvRows(): array
+        public static function getExtraCsvRows(): array
     {
         return [
             [

--- a/app/Models/LookupTables/Crop.php
+++ b/app/Models/LookupTables/Crop.php
@@ -9,7 +9,7 @@ class Crop extends LookupEntry
 {
     use CanBeHiddenFromContext;
 
-    public function getExtraCsvRows(): array
+    public static function getExtraCsvRows(): array
     {
         return [
             [

--- a/app/Models/LookupTables/Crop.php
+++ b/app/Models/LookupTables/Crop.php
@@ -9,6 +9,80 @@ class Crop extends LookupEntry
 {
     use CanBeHiddenFromContext;
 
+    public function getExtraCsvRows(): array
+    {
+        return [
+            [
+                'id' => null,
+                'name' => 77,
+                'label' => "Other crops",
+                'is_in_context' => 1,
+            ],
+            [
+                'id' => null,
+                'name' => 800,
+                'label' => 'Other agave fibres',
+                'is_in_context' => 0,
+            ],
+            [
+                'id' => null,
+                'name' => 782,
+                'label' => 'Other bastfibres',
+                'is_in_context' => 0,
+            ],
+            [
+                'id' => null,
+                'name' => 108,
+                'label' => 'Other cereals',
+                'is_in_context' => 0,
+            ],
+            [
+                'id' => null,
+                'name' => 821,
+                'label' => 'Other fibre crops',
+                'is_in_context' => 0,
+            ],
+            [
+                'id' => null,
+                'name' => 339,
+                'label' => 'Other oilseeds',
+                'is_in_context' => 0,
+            ],
+            [
+                'id' => null,
+                'name' => 149,
+                'label' => 'Other roots and tubers',
+                'is_in_context' => 0,
+            ],
+            [
+                'id' => null,
+                'name' => 161,
+                'label' => 'Other sugar crops',
+                'is_in_context' => 0,
+            ],
+            [
+                'id' => null,
+                'name' => 777770,
+                'label' => 'Other fruits',
+                'is_in_context' => 0,
+            ],
+            [
+                'id' => null,
+                'name' => 777771,
+                'label' => 'Other vegetables',
+                'is_in_context' => 0,
+            ],
+            [
+                'id' => null,
+                'name' => 77,
+                'label' => 'Other crops (that do not fit into another category)',
+                'is_in_context' => 0,
+            ],
+
+        ];
+
+    }
+
     public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         if ($team) {

--- a/app/Models/LookupTables/CropProduct.php
+++ b/app/Models/LookupTables/CropProduct.php
@@ -9,6 +9,30 @@ class CropProduct extends LookupEntry
 {
     use CanBeHiddenFromContext;
 
+    public function getExtraCsvRows(): array
+    {
+        return [
+            [
+                'id' => null,
+                'name' => 77,
+                'label' => 'Other',
+                'is_in_context' => 1,
+            ],
+            [
+                'id' => null,
+                'name' => -97,
+                'label' => 'None',
+                'is_in_context' => 1,
+            ],
+            [
+                'id' => null,
+                'name' => 77,
+                'label' => 'Other',
+                'is_in_context' => 0,
+            ],
+        ];
+    }
+
     public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         if ($team) {

--- a/app/Models/LookupTables/CropProduct.php
+++ b/app/Models/LookupTables/CropProduct.php
@@ -9,7 +9,7 @@ class CropProduct extends LookupEntry
 {
     use CanBeHiddenFromContext;
 
-    public function getExtraCsvRows(): array
+    public static function getExtraCsvRows(): array
     {
         return [
             [

--- a/app/Models/LookupTables/Enumerator.php
+++ b/app/Models/LookupTables/Enumerator.php
@@ -6,6 +6,17 @@ use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 class Enumerator extends LookupEntry
 {
+        public function getExtraCsvRows(): array
+    {
+        return [
+            [
+                'id' => null,
+                'name' => 77,
+                'label' => 'Name not on the list / other',
+            ],
+        ];
+    }
+
     public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         return [

--- a/app/Models/LookupTables/Enumerator.php
+++ b/app/Models/LookupTables/Enumerator.php
@@ -6,7 +6,7 @@ use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 
 class Enumerator extends LookupEntry
 {
-        public function getExtraCsvRows(): array
+    public static function getExtraCsvRows(): array
     {
         return [
             [

--- a/app/Models/LookupTables/LookupEntry.php
+++ b/app/Models/LookupTables/LookupEntry.php
@@ -33,6 +33,15 @@ class LookupEntry extends Model implements LookupListEntry
         return false;
     }
 
+    /**
+     * Function to generate any extra rows that are always required for the csv lookup file (e.g. "other", "none", etc)
+     * When using search(), these rows are usually specified in the XLSform itself, but when using select_*_from_file all the entries must be in the file)
+     */
+    public function getExtraCsvRows(): ?array
+    {
+        return null;
+    }
+
     // Generic CSV content. Should be overwritten by specific classes when the csv file contents needs to be specific.
     public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {

--- a/app/Models/LookupTables/LookupEntry.php
+++ b/app/Models/LookupTables/LookupEntry.php
@@ -37,7 +37,7 @@ class LookupEntry extends Model implements LookupListEntry
      * Function to generate any extra rows that are always required for the csv lookup file (e.g. "other", "none", etc)
      * When using search(), these rows are usually specified in the XLSform itself, but when using select_*_from_file all the entries must be in the file)
      */
-    public function getExtraCsvRows(): ?array
+    public static function getExtraCsvRows(): ?array
     {
         return null;
     }

--- a/app/Models/SampleFrame/Farm.php
+++ b/app/Models/SampleFrame/Farm.php
@@ -39,7 +39,7 @@ class Farm extends LookupEntry
         return $this->hasMany(PerformanceAssessment::class);
     }
 
-    public function getExtraCsvRows(): array
+    public static function getExtraCsvRows(): array
     {
         return [
             [

--- a/app/Models/SampleFrame/Farm.php
+++ b/app/Models/SampleFrame/Farm.php
@@ -39,6 +39,34 @@ class Farm extends LookupEntry
         return $this->hasMany(PerformanceAssessment::class);
     }
 
+    public function getExtraCsvRows(): array
+    {
+        return [
+            [
+                'id' => -99,
+                'location_id' => null,
+                'location_name' => null,
+                'team_code' => null,
+                'team_code_name' => 'Farm not displayed in list',
+                'name' => null,
+                'sex' => null,
+                'year' => null,
+                'reserve' => 0,
+            ],
+            [
+                'id' => -98,
+                'location_id' => null,
+                'location_name' => null,
+                'team_code' => null,
+                'team_code_name' => 'HHs in list not available for interview',
+                'name' => null,
+                'sex' => null,
+                'year' => null,
+                'reserve' => 0,
+            ],
+        ];
+    }
+
     public function getCsvContentsForOdk(?WithXlsforms $team = null): array
     {
         return [


### PR DESCRIPTION
To try and make Enketo available for form review / submission editing, I've moved the ODK form to use `select_one_from_file` and `select_multiple_from_file` instead of `search()`. This means the various static options like "other", or "none" must be inside the csv files generated from the platform. 

This PR does exactly that - it adds a function to the LookupEntry models that returns the correct array of data to append rows to the end of the csv files. 

This might not be the best approach long-term - we probably want the user to be able to manage these entries. But for now this approach works ok to get the extra rows and make sure they are always at the bottom of the lookup lists. 

