### PR TITLE
Monitoring dashboard - Rough

### DIFF
--- a/app/Filament/App/Pages/TeamOdkView.php
+++ b/app/Filament/App/Pages/TeamOdkView.php
@@ -118,10 +118,6 @@ class TeamOdkView extends Page implements HasTable, HasInfolists
                     ->url(fn (Xlsform $record) => XlsformResource::getUrl('view', ['record' => $record]))
                     ->label('Show Submissions'),
 
-                TableAction::make('monitor survey')
-                    ->url(fn (Xlsform $record) => XlsformResource::getUrl('monitor', ['record' => $record]))
-                    ->label('Monitor Survey'),
-
                 // add Publish button
                 TableAction::make('publish')
                     ->label('Publish')

--- a/app/Filament/App/Resources/XlsformResource.php
+++ b/app/Filament/App/Resources/XlsformResource.php
@@ -4,14 +4,12 @@ namespace App\Filament\App\Resources;
 
 use App\Filament\App\Resources\XlsformResource\Pages;
 use App\Filament\App\Resources\XlsformResource\RelationManagers;
-use Filament\Forms;
 use Filament\Forms\Form;
+use Filament\Infolists\Components\ViewEntry;
+use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
 
 class XlsformResource extends Resource
@@ -21,6 +19,16 @@ class XlsformResource extends Resource
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
     protected static ?string $tenantOwnershipRelationshipName = 'owner';
 
+
+    public static function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                ViewEntry::make('submission_summary')
+                ->view('submission_summary_wrapper')
+                ->columnSpanFull()
+            ]);
+    }
 
     public static function form(Form $form): Form
     {

--- a/app/Filament/App/Resources/XlsformResource/Pages/MonitorXlsform.php
+++ b/app/Filament/App/Resources/XlsformResource/Pages/MonitorXlsform.php
@@ -39,6 +39,8 @@ class MonitorXlsform extends Page
         return $summary;
     }
 
+
+    // TODO: Update this to link to the formatted Excel version
     public function exportAsExcelFile()
     {
         $odkLinkService = app()->make(OdkLinkService::class);

--- a/app/Filament/App/Resources/XlsformResource/Pages/ViewXlsform.php
+++ b/app/Filament/App/Resources/XlsformResource/Pages/ViewXlsform.php
@@ -4,12 +4,9 @@ namespace App\Filament\App\Resources\XlsformResource\Pages;
 
 use App\Filament\App\Resources\XlsformResource;
 use App\Http\Controllers\SurveyMonitoringController;
-use Filament\Actions;
 use Filament\Actions\Action;
 use Filament\Resources\Pages\ViewRecord;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Http;
 use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
 
 class ViewXlsform extends ViewRecord
@@ -21,6 +18,16 @@ class ViewXlsform extends ViewRecord
     public function getHeading(): string|Htmlable
     {
         return 'Submissions for form: ' . $this->record->title;
+    }
+
+    public function hasCombinedRelationManagerTabsWithContent(): bool
+    {
+        return true;
+    }
+
+    public function getContentTabLabel(): ?string
+    {
+        return 'Summary';
     }
 
     // Question: This function is being called twice now...

--- a/app/Filament/App/Resources/XlsformResource/RelationManagers/SubmissionsRelationManager.php
+++ b/app/Filament/App/Resources/XlsformResource/RelationManagers/SubmissionsRelationManager.php
@@ -52,7 +52,7 @@ class SubmissionsRelationManager extends RelationManager
                      if($enumeratorId === "77") {
                          return $record->content['survey_start']['inquirer_text'];
                      }
-                     return Enumerator::firstWhere('name', $record->content['survey_start']['inquirer_choice']) ?? '~not found~';
+                     return Enumerator::firstWhere('name', $record->content['survey_start']['inquirer_choice'])->name ?? '~not found~';
                  }),
                  Tables\Columns\TextColumn::make('farm_name')
                      ->getStateUsing(function ($record) {

--- a/app/Filament/App/Resources/XlsformResource/RelationManagers/SubmissionsRelationManager.php
+++ b/app/Filament/App/Resources/XlsformResource/RelationManagers/SubmissionsRelationManager.php
@@ -45,14 +45,15 @@ class SubmissionsRelationManager extends RelationManager
             ->recordTitleAttribute('odk_id')
             ->columns([
                 Tables\Columns\TextColumn::make('odk_id'),
-                Tables\Columns\TextColumn::make('submitted_at'),
+                Tables\Columns\TextColumn::make('submitted_at')
+                ->sortable(),
                  Tables\Columns\TextColumn::make('enumerator')
                  ->getStateUsing(function ($record) {
                      $enumeratorId = $record->content['survey_start']['inquirer_choice'];
                      if($enumeratorId === "77") {
                          return $record->content['survey_start']['inquirer_text'];
                      }
-                     return Enumerator::firstWhere('name', $record->content['survey_start']['inquirer_choice'])->name ?? '~not found~';
+                     return Enumerator::firstWhere('name', $record->content['survey_start']['inquirer_choice'])->label ?? '~not found~';
                  }),
                  Tables\Columns\TextColumn::make('farm_name')
                      ->getStateUsing(function ($record) {

--- a/resources/views/filament/app/resources/xlsform-resource/pages/monitor-xlsform.blade.php
+++ b/resources/views/filament/app/resources/xlsform-resource/pages/monitor-xlsform.blade.php
@@ -1,22 +1,5 @@
 <x-filament-panels::page>
 
-    <x-filament::section>
-        <x-slot name="heading">
-            <b>Live Submissions</b>
-        </x-slot>
-        <p>
-            <b>Number of Live Submissions:</b> {{ $this->getSummary()['count'] }}
-        </p>
-        <br />
-        <p>
-            <b>Latest Submission:</b> {{ $this->getSummary()['latestSubmissionDate'] }}
-        </p>
-        <br />
-        <p>
-            <b>Submissions In Local Database:</b> {{ count($this->record->submissions) }}
-            <br />
-            <small>The Live Submissions count above is updated in real time. The number of submissions in the local database may not be fully up to date due to the time it takes to sync with the ODK System.</small>
-        </p>
-    </x-filament::section>
+
 
 </x-filament-panels::page>

--- a/resources/views/filament/app/resources/xlsform-resource/pages/view-xlsform.blade.php
+++ b/resources/views/filament/app/resources/xlsform-resource/pages/view-xlsform.blade.php
@@ -8,6 +8,10 @@
     @php
         $relationManagers = $this->getRelationManagers();
         $hasCombinedRelationManagerTabsWithContent = $this->hasCombinedRelationManagerTabsWithContent();
+
+
+        $summary = $this->getSummary();
+
     @endphp
 
     @if ((! $hasCombinedRelationManagerTabsWithContent) || (! count($relationManagers)))
@@ -22,24 +26,55 @@
         @endif
     @endif
 
-    <x-filament::section>
-        <x-slot name="heading">
-            <b>Live Submissions</b>
-        </x-slot>
-        <p>
-            <b>Number of Live Submissions:</b> {{ $this->getSummary()['count'] }}
-        </p>
-        <br />
-        <p>
-            <b>Latest Submission:</b> {{ $this->getSummary()['latestSubmissionDate'] }}
-        </p>
-        <br />
-        <p>
-            <b>Submissions In Local Database:</b> {{ count($this->getRecord()->submissions) }}
-            <br />
-            <small>The Live Submissions count above is updated in real time. The number of submissions in the local database may not be fully up to date due to the time it takes to sync with the ODK System.</small>
-        </p>
-    </x-filament::section>
+    <div class="grid grid-cols-2 gap-x-8">
+
+        <x-filament::section>
+            <x-slot name="heading">
+                <b>Live Submissions</b>
+            </x-slot>
+            <p>
+                <b>Number of Live Submissions:</b> {{ $summary['count'] }}
+            </p>
+            <br/>
+            <p>
+                <b>Number of Completed Surveys:</b> {{ $summary['successfulSurveys'] }}
+                <br/>
+                <small>(Not including non-responses or non-consents)</small>
+            </p>
+            <br/>
+            <p>
+                <b>Latest Submission:</b> {{ $summary['latestSubmissionDate'] }}
+            </p>
+            <br/>
+            <p>
+                <b>Submissions In Local Database:</b> {{ count($this->record->submissions) }}
+                <br/>
+                <small>The Live Submissions count above is updated in real time. The number of submissions in the local database may not be fully up to date due to the time it takes to sync with the ODK System.</small>
+            </p>
+        </x-filament::section>
+
+        <x-filament::section>
+            <x-slot name="heading">
+                <b>Summary</b>
+            </x-slot>
+
+            <div class="grid grid-cols-2 gap-4">
+
+                <b>Surveys Without Respondent Present</b>
+                <span>{{ $summary['surveysWithoutRespondentPresent'] }}</span>
+
+                <b>Surveys With Non-Consenting Respondent</b>
+                <span>{{ $summary['surveysWithNonConsentingRespondent'] }}</span>
+
+                <b>Beneficiary Farms Fully Surveyed:</b>
+                <span>{{ $summary['beneficiaryFarmsSurveyed'] }} / 60 </span>
+
+                <b>Non-Beneficiary Farms Fully Surveyed:</b>
+                <span>{{ $summary['nonBeneficiaryFarmsSurveyed'] }} / 60</span>
+            </div>
+        </x-filament::section>
+    </div>
+
 
     @if (count($relationManagers))
         <x-filament-panels::resources.relation-managers

--- a/resources/views/submission_summary_wrapper.blade.php
+++ b/resources/views/submission_summary_wrapper.blade.php
@@ -1,0 +1,54 @@
+@php
+
+    $locations = \App\Models\SampleFrame\Location::where('owner_id', \App\Services\HelperService::getSelectedTeam()->id)->get();
+
+    $submissions = $getRecord()->submissions;
+
+    $submissionsByLocations = $submissions->map(function(\Stats4sd\FilamentOdkLink\Models\OdkLink\Submission $submission) {
+
+        $submission->location_id = $submission->content['reg']['final_location_id'];
+
+        return $submission;
+    })
+    ->groupBy('location_id');
+
+    $submissionsByEnumerators = $submissions->map(function(\Stats4sd\FilamentOdkLink\Models\OdkLink\Submission $submission) {
+
+        $submission->enumerator_id = $submission->content['survey_start']['inquirer'];
+
+        return $submission;
+    })->groupBy('enumerator_id');
+
+@endphp
+
+<div class="grid grid-cols-2 gap-8">
+
+    <x-filament::section>
+        <x-slot name="heading">
+            <b>Submissions By Location</b>
+        </x-slot>
+
+        <div class="grid grid-cols-3 gap-3">
+            @foreach($submissionsByLocations as $key => $locationFromSubmission)
+                <b class="text-right">{{ $locations->firstWhere('id', $key)?->name ?? $key }}</b>
+                <span class="col-span-2"">{{ $locationFromSubmission->count() }}</span>
+            @endforeach
+        </div>
+
+    </x-filament::section>
+
+    <x-filament::section>
+        <x-slot name="heading">
+            <b>Submissions By Enumerator</b>
+        </x-slot>
+
+        <div class="grid grid-cols-3 gap-3">
+            @foreach($submissionsByEnumerators as $key => $enumeratorSubmissions)
+                <b class="text-right col-span-2">{{ \Illuminate\Support\Str::replace("_", " ", $key) }}</b>
+                <span>{{ $enumeratorSubmissions->count() }}</span>
+
+            @endforeach
+        </div>
+
+    </x-filament::section>
+</div>


### PR DESCRIPTION
This PR is for a quick and rough monitoring dashboard, containing survey counts

- by "completed survey vs non-responses (either respondents were not available or did not consent)"
- by location
- by enumerator.

It's not a very elegant approach, but hopefully enough to give the current survey supervisors something to use. 

![CleanShot 2024-05-20 at 15 59 58](https://github.com/stats4sd/tape-data-system/assets/5711101/84f82776-0fbc-4cad-ba1e-6826b252fc75)

![CleanShot 2024-05-20 at 15 59 54](https://github.com/stats4sd/tape-data-system/assets/5711101/a1f9f7d7-8c42-45ab-ac07-194c5ee16bca)
