### PR TITLE
Fix Zero Showed as Empty Cell In Data Extraction

### DIFF
--- a/app/Exports/PerformanceExport.php
+++ b/app/Exports/PerformanceExport.php
@@ -9,8 +9,9 @@ use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Concerns\WithTitle;
+use Maatwebsite\Excel\Concerns\WithStrictNullComparison;
 
-class PerformanceExport implements FromQuery, WithTitle, WithHeadings, WithMapping
+class PerformanceExport implements FromQuery, WithTitle, WithHeadings, WithMapping, WithStrictNullComparison
 {
     public string $title;
     public array $fields;


### PR DESCRIPTION
This PR is submitted to fix below issue:
1. Zero values are showed as empty cells in data extraction excel file

Performed testing in local env, with positive result.

P.S. Live env is now connecting to dev branch. Therefore this PR will be merged into dev branch for live env deployment.

---

Reference:
https://docs.laravel-excel.com/3.1/exports/collection.html#strict-null-comparisons

---

Screen shots:

Database table:
![image](https://github.com/stats4sd/tape-data-system/assets/86968034/d019220b-e418-430f-8f27-4cc4c6eee347)

BEFORE:
![image](https://github.com/stats4sd/tape-data-system/assets/86968034/415b0451-0a9a-4bfc-aea4-5413d8fa43f9)

AFTER:
![image](https://github.com/stats4sd/tape-data-system/assets/86968034/cb0efc6a-b1cb-4266-8829-07c9c4fd3e7c)
