### PR TITLE
Add Sentry Crons Monitor

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -5,5 +5,5 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
 use Stats4sd\FilamentOdkLink\Commands\PollForOdkData;
 
-Schedule::command(PurgeTelescopeEntries::class)->daily();
-Schedule::command(PollForOdkData::class)->everyFiveMinutes();
+Schedule::command(PurgeTelescopeEntries::class)->daily()->sentryMonitor();
+Schedule::command(PollForOdkData::class)->everyFiveMinutes()->sentryMonitor();


### PR DESCRIPTION
This PR is submitted to add sentry crons monitor.

I am not able to perform testing in local env. We will need to deploy this patch to staging env for testing.

---

Reference:
https://docs.sentry.io/platforms/php/guides/laravel/crons/