### PR TITLE
Add GPS Details

### DIFF
--- a/app/Console/Commands/AddGpsDetails.php
+++ b/app/Console/Commands/AddGpsDetails.php
@@ -31,9 +31,11 @@ class AddGpsDetails extends Command
         $this->info('start');
 
         // find all main surveys records
-        $mainSurveys = MainSurvey::all();
+        $mainSurveys = MainS6urvey::all();
 
         $this->info('Processing ' . count($mainSurveys) . ' main survey records...');
+
+        $countMissing = 0;
 
         // handle all main survey records one by one
         foreach ($mainSurveys as $mainSurvey) {
@@ -59,10 +61,11 @@ class AddGpsDetails extends Command
             $this->comment($mainSurvey->respondent_name . ' main survey updated');
 
             // find the corresponding farms record
-            $farm = Farm::where('identifiers->name', $mainSurvey->respondent_name)->first();
+            $farm = $mainSurvey->farm;
 
             if (!$farm) {
                 $this->comment('*** ' . $mainSurvey->respondent_name . ' FARM NOT FOUND');
+                $countMissing++;
                 continue;
             }
 

--- a/app/Console/Commands/AddGpsDetails.php
+++ b/app/Console/Commands/AddGpsDetails.php
@@ -56,7 +56,7 @@ class AddGpsDetails extends Command
             $mainSurvey->longitude = $longitude;
             $mainSurvey->altitude = $altitude;
             $mainSurvey->accuracy = $accuracy;
-            // $mainSurvey->save();
+            $mainSurvey->save();
 
             $this->comment($mainSurvey->respondent_name . ' main survey updated');
 
@@ -75,7 +75,7 @@ class AddGpsDetails extends Command
             $farm->longitude = $longitude;
             $farm->altitude = $altitude;
             $farm->accuracy = $accuracy;
-            // $farm->save();
+            $farm->save();
         }
 
         $this->info(count($mainSurveys) . ' main survey records processed');

--- a/app/Console/Commands/AddGpsDetails.php
+++ b/app/Console/Commands/AddGpsDetails.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\SampleFrame\Farm;
+use App\Models\SurveyData\MainSurvey;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Submission;
+
+class AddGpsDetails extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:add-gps-details';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Find GPS details from submissions.content, add it to main_surveys table and farms table';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->info('start');
+
+        // find all main surveys records
+        $mainSurveys = MainSurvey::all();
+
+        $this->info('Processing ' . count($mainSurveys) . ' main survey records...');
+
+        // handle all main survey records one by one
+        foreach ($mainSurveys as $mainSurvey) {
+            // find the corresponding submissions record
+            $submission = Submission::find($mainSurvey->submission_id);
+
+            // get ODK submission JSON content
+            $data = $submission->content;
+
+            // find GPS details from ODK submission JSON content
+            $latitude = $data['farm_info']['gps_loc']['coordinates'][0];
+            $longitude = $data['farm_info']['gps_loc']['coordinates'][1];
+            $altitude = $data['farm_info']['gps_loc']['coordinates'][2];
+            $accuracy = $data['farm_info']['gps_loc']['properties']['accuracy'];
+
+            // save GPS details to main_surveys record
+            $mainSurvey->latitude = $latitude;
+            $mainSurvey->longitude = $longitude;
+            $mainSurvey->altitude = $altitude;
+            $mainSurvey->accuracy = $accuracy;
+            $mainSurvey->save();
+
+            $this->comment($mainSurvey->respondent_name . ' main survey updated');
+
+            // find the corresponding farms record
+            $farm = Farm::where('identifiers->name', $mainSurvey->respondent_name)->first();
+
+            if (!$farm) {
+                $this->comment('*** ' . $mainSurvey->respondent_name . ' FARM NOT FOUND');
+                continue;
+            }
+
+            $this->comment($mainSurvey->respondent_name . ' farm updated');
+            // save GPS details to farms record
+            $farm->latitude = $latitude;
+            $farm->longitude = $longitude;
+            $farm->altitude = $altitude;
+            $farm->accuracy = $accuracy;
+            $farm->save();
+        }
+
+        $this->info(count($mainSurveys) . ' main survey records processed');
+
+        $this->info('end');
+    }
+}

--- a/app/Console/Commands/AddGpsDetails.php
+++ b/app/Console/Commands/AddGpsDetails.php
@@ -31,7 +31,7 @@ class AddGpsDetails extends Command
         $this->info('start');
 
         // find all main surveys records
-        $mainSurveys = MainS6urvey::all();
+        $mainSurveys = MainSurvey::all();
 
         $this->info('Processing ' . count($mainSurveys) . ' main survey records...');
 
@@ -56,7 +56,7 @@ class AddGpsDetails extends Command
             $mainSurvey->longitude = $longitude;
             $mainSurvey->altitude = $altitude;
             $mainSurvey->accuracy = $accuracy;
-            $mainSurvey->save();
+            // $mainSurvey->save();
 
             $this->comment($mainSurvey->respondent_name . ' main survey updated');
 
@@ -75,10 +75,11 @@ class AddGpsDetails extends Command
             $farm->longitude = $longitude;
             $farm->altitude = $altitude;
             $farm->accuracy = $accuracy;
-            $farm->save();
+            // $farm->save();
         }
 
         $this->info(count($mainSurveys) . ' main survey records processed');
+        $this->info($countMissing . ' farms NOT FOUND');
 
         $this->info('end');
     }

--- a/database/migrations/2024_07_12_115248_update_main_surveys_table.php
+++ b/database/migrations/2024_07_12_115248_update_main_surveys_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('main_surveys', function (Blueprint $table) {
+            // GPS location
+            $table->decimal('accuracy', 9, 4)->nullable()->after('respondent_phone');
+            $table->integer('altitude')->nullable()->after('respondent_phone');
+            $table->decimal('longitude', 11, 8)->nullable()->after('respondent_phone');
+            $table->decimal('latitude', 11, 8)->nullable()->after('respondent_phone');
+
+            $table->dropColumn('gps_loc');
+        });
+
+        Schema::table('farms', function (Blueprint $table) {
+            // GPS location
+            $table->decimal('accuracy', 9, 4)->nullable()->after('altitude');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};


### PR DESCRIPTION
This PR is submitted to fix #76 

User requested to show GPS co-ordinates.

---

This PR contains below changes:
 - main_surveys table, remove un-used column gps_loc, add new columns latitude, longitude, altitude, accuracy
 - farms table, add new column accuracy
 - add one-time command program:
   - for each main_surveys record, find GPS details from the corresponding submissions.content JSON content
   - add GPS details to main_surveys table 
   - add GPS details to farms table
   - 4 new columns for GPS details will be showed in "Main_Survey" sheet in data extraction

---

P.S. I did a try run in live env (without updating records), there are 50 / 127 farms cannot be found when running this command program. Suppose it has no impact as we do not extract farms records to excel file.

---

Revised way for preparing the finalised excel file to user.
1. Find the latest excel file with boolean extraction for select_multiple columns (the one that Dave sent to Joe by email)
2. Copy the 4 new columns for GPS details from to that excel file