### PR TITLE
Fix GPS Details

### DIFF
--- a/app/Console/Commands/AddGpsDetails.php
+++ b/app/Console/Commands/AddGpsDetails.php
@@ -46,8 +46,8 @@ class AddGpsDetails extends Command
             $data = $submission->content;
 
             // find GPS details from ODK submission JSON content
-            $latitude = $data['farm_info']['gps_loc']['coordinates'][0];
-            $longitude = $data['farm_info']['gps_loc']['coordinates'][1];
+            $latitude = $data['farm_info']['gps_loc']['coordinates'][1];
+            $longitude = $data['farm_info']['gps_loc']['coordinates'][0];
             $altitude = $data['farm_info']['gps_loc']['coordinates'][2];
             $accuracy = $data['farm_info']['gps_loc']['properties']['accuracy'];
 


### PR DESCRIPTION
This PR is submitted to fix issue #79 

After doing some sample check with google map, by entering latitude and longitude, e.g. 
38.51168390, 9.05154230 (it is an ocean...)
9.05154230, 38.51168390  (it is Ethiopia)

It looks like GPS data latitude and longitude were interchanged.

---

This PR contains below change:
1. Make correction in the one-time program to get GPS data from ODK submission JSON content

Deployment procedure:
1. Deploy this patch to live env
2. Manually run the one-time program to update GPS data for main_surveys and farms